### PR TITLE
Remove two non-required Application Settings from Bicep Template

### DIFF
--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -236,10 +236,6 @@ resource func 'Microsoft.Web/sites@2022-03-01' = {
           value: '@Microsoft.KeyVault(VaultName=${kv.name};SecretName=StorageAccount-ConnectionString)'
         }
         {
-          name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'
-          value: '@Microsoft.KeyVault(VaultName=${kv.name};SecretName=StorageAccount-ConnectionString)'
-        }
-        {
           name: 'COSMOS_CONNECTION_STRING'
           value: cosmosEnabled ? '@Microsoft.KeyVault(VaultName=${kv.name};SecretName=CosmosDB-ConnectionString)' : 'null'
         }
@@ -250,10 +246,6 @@ resource func 'Microsoft.Web/sites@2022-03-01' = {
         {
           name: 'STORAGE_ENABLED'
           value: '${storageExportEnabled}'
-        }
-        {
-          name: 'WEBSITE_CONTENTSHARE'
-          value: toLower(functionAppName)
         }
         {
           name: 'FUNCTIONS_EXTENSION_VERSION'

--- a/infrastructure/main.json
+++ b/infrastructure/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.14.6.61914",
-      "templateHash": "10794450940481993912"
+      "version": "0.23.1.45101",
+      "templateHash": "6593082609327719224"
     }
   },
   "parameters": {
@@ -324,10 +324,6 @@
               "value": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=StorageAccount-ConnectionString)', parameters('keyVaultName'))]"
             },
             {
-              "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=StorageAccount-ConnectionString)', parameters('keyVaultName'))]"
-            },
-            {
               "name": "COSMOS_CONNECTION_STRING",
               "value": "[if(parameters('cosmosEnabled'), format('@Microsoft.KeyVault(VaultName={0};SecretName=CosmosDB-ConnectionString)', parameters('keyVaultName')), 'null')]"
             },
@@ -338,10 +334,6 @@
             {
               "name": "STORAGE_ENABLED",
               "value": "[format('{0}', parameters('storageExportEnabled'))]"
-            },
-            {
-              "name": "WEBSITE_CONTENTSHARE",
-              "value": "[toLower(parameters('functionAppName'))]"
             },
             {
               "name": "FUNCTIONS_EXTENSION_VERSION",


### PR DESCRIPTION
Remove two Function App Application Settings that are not required for consumption plan deployments. These settings being configured as Key Vault references caused the deployment of the Function App to fail due to a dependency on access to the Key Vault at Function App deployment time.